### PR TITLE
Update `order` property type in AI assistant and prompt schemas

### DIFF
--- a/ai/assistant/v0.1.0/schema.json
+++ b/ai/assistant/v0.1.0/schema.json
@@ -19,7 +19,7 @@
           "description": "The user-friendly label"
         },
         "order": {
-          "type": "integer",
+          "type": "number",
           "title": "Order"
         }
       },

--- a/ai/assistant/v0.1.0/schema.json
+++ b/ai/assistant/v0.1.0/schema.json
@@ -7,7 +7,12 @@
   "description": "AI assistants and their configuration",
   "type": "object",
   "database": {
-    "name": "ai_assistant"
+    "name": "ai_assistant",
+    "indexes": {
+      "order": ["order", "insertedAt"],
+      "name": ["name", "insertedAt"],
+      "insertedAt": ["insertedAt"]
+    }
   },
   "allOf": [
     { "$ref": "https://core.schemas.verida.io/base/v0.1.0/schema.json" },

--- a/ai/prompt/v0.1.0/schema.json
+++ b/ai/prompt/v0.1.0/schema.json
@@ -7,7 +7,12 @@
   "description": "Saved prompts for the assistant",
   "type": "object",
   "database": {
-    "name": "ai_prompt"
+    "name": "ai_prompt",
+    "indexes": {
+      "order": ["order", "insertedAt"],
+      "name": ["name", "insertedAt"],
+      "insertedAt": ["insertedAt"]
+    }
   },
   "allOf": [
     { "$ref": "https://core.schemas.verida.io/base/v0.1.0/schema.json" },

--- a/ai/prompt/v0.1.0/schema.json
+++ b/ai/prompt/v0.1.0/schema.json
@@ -29,7 +29,7 @@
           "description": "The actual prompt"
         },
         "order": {
-          "type": "integer",
+          "type": "number",
           "title": "Order"
         }
       },


### PR DESCRIPTION
Allow `order` to be a decimal